### PR TITLE
Add user dashboard view

### DIFF
--- a/resources/views/dashboard.blade.php
+++ b/resources/views/dashboard.blade.php
@@ -1,0 +1,8 @@
+@extends('layouts.app')
+
+@section('title', 'Dashboard')
+
+@section('content')
+    <h1 class="text-2xl font-bold mb-4">User Dashboard</h1>
+    <p>Welcome to your dashboard.</p>
+@endsection

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="{{ str_replace('_', '-', app()->getLocale()) }}">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>@yield('title', 'Fundi Portal')</title>
+    @vite(['resources/css/app.css', 'resources/js/app.js'])
+</head>
+<body class="font-sans antialiased bg-gray-100">
+    <nav class="bg-white border-b border-gray-200">
+        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-4 flex justify-between">
+            <a href="/" class="text-lg font-semibold text-gray-700">Fundi Portal</a>
+            <div>
+                <a href="/dashboard" class="text-gray-700 hover:text-gray-900 px-3">Dashboard</a>
+            </div>
+        </div>
+    </nav>
+    <main class="py-6">
+        <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
+            @yield('content')
+        </div>
+    </main>
+</body>
+</html>

--- a/routes/web.php
+++ b/routes/web.php
@@ -5,3 +5,5 @@ use Illuminate\Support\Facades\Route;
 Route::get('/', function () {
     return view('welcome');
 });
+
+Route::view('/dashboard', 'dashboard')->name('dashboard');

--- a/tests/Feature/DashboardTest.php
+++ b/tests/Feature/DashboardTest.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Tests\Feature;
+
+use Tests\TestCase;
+
+class DashboardTest extends TestCase
+{
+    /**
+     * Ensure the dashboard page is accessible.
+     */
+    public function test_dashboard_page_is_accessible(): void
+    {
+        $response = $this->get('/dashboard');
+
+        $response->assertStatus(200);
+        $response->assertSee('User Dashboard');
+    }
+}


### PR DESCRIPTION
## Summary
- add reusable layout template
- implement a simple dashboard page
- register `/dashboard` route
- test dashboard route

## Testing
- `php artisan test` *(fails: vendor folder missing; composer download blocked)*

------
https://chatgpt.com/codex/tasks/task_e_684c3c452de48331acb5cc06c3f4f6f7