### PR TITLE
Add user login and dashboard access

### DIFF
--- a/app/Http/Controllers/Auth/LoginController.php
+++ b/app/Http/Controllers/Auth/LoginController.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace App\Http\Controllers\Auth;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+
+class LoginController extends Controller
+{
+    /**
+     * Display the login form.
+     */
+    public function showLoginForm()
+    {
+        return view('auth.login');
+    }
+
+    /**
+     * Handle an authentication attempt.
+     */
+    public function login(Request $request)
+    {
+        $credentials = $request->validate([
+            'email' => ['required', 'email'],
+            'password' => ['required', 'string'],
+        ]);
+
+        $remember = $request->boolean('remember');
+
+        if (Auth::attempt($credentials, $remember)) {
+            $request->session()->regenerate();
+
+            return redirect()->intended(route('dashboard'));
+        }
+
+        return back()->withErrors([
+            'email' => 'Invalid credentials',
+        ])->onlyInput('email');
+    }
+
+    /**
+     * Log the user out of the application.
+     */
+    public function logout(Request $request)
+    {
+        Auth::logout();
+
+        $request->session()->invalidate();
+        $request->session()->regenerateToken();
+
+        return redirect('/');
+    }
+}

--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -24,10 +24,12 @@ class UserFactory extends Factory
     public function definition(): array
     {
         return [
-            'name' => fake()->name(),
-            'email' => fake()->unique()->safeEmail(),
-            'email_verified_at' => now(),
-            'password' => static::$password ??= Hash::make('password'),
+            'first_name' => fake()->firstName(),
+            'last_name'  => fake()->lastName(),
+            'email'      => fake()->unique()->safeEmail(),
+            'phone'      => fake()->phoneNumber(),
+            'password'   => static::$password ??= Hash::make('password'),
+            'status'     => 'active',
             'remember_token' => Str::random(10),
         ];
     }

--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -1,0 +1,32 @@
+@extends('layouts.app')
+
+@section('title', 'Login')
+
+@section('content')
+    <div class="max-w-md mx-auto bg-white p-6 rounded shadow">
+        <h1 class="text-2xl font-bold mb-4">Login</h1>
+        @if($errors->any())
+            <div class="mb-4 text-red-600">
+                {{ $errors->first() }}
+            </div>
+        @endif
+        <form method="POST" action="{{ route('login') }}" class="space-y-4">
+            @csrf
+            <div>
+                <label for="email" class="block text-sm font-medium text-gray-700">Email</label>
+                <input id="email" type="email" name="email" value="{{ old('email') }}" required autofocus class="mt-1 block w-full border-gray-300 rounded" />
+            </div>
+            <div>
+                <label for="password" class="block text-sm font-medium text-gray-700">Password</label>
+                <input id="password" type="password" name="password" required class="mt-1 block w-full border-gray-300 rounded" />
+            </div>
+            <div class="flex items-center">
+                <input id="remember" type="checkbox" name="remember" class="h-4 w-4 text-indigo-600 border-gray-300 rounded" />
+                <label for="remember" class="ml-2 block text-sm text-gray-900">Remember me</label>
+            </div>
+            <div>
+                <button type="submit" class="w-full py-2 px-4 bg-indigo-600 text-white rounded hover:bg-indigo-700">Login</button>
+            </div>
+        </form>
+    </div>
+@endsection

--- a/resources/views/dashboard.blade.php
+++ b/resources/views/dashboard.blade.php
@@ -1,0 +1,8 @@
+@extends('layouts.app')
+
+@section('title', 'Dashboard')
+
+@section('content')
+    <h1 class="text-2xl font-bold mb-4">User Dashboard</h1>
+    <p>Welcome to your dashboard.</p>
+@endsection

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="{{ str_replace('_', '-', app()->getLocale()) }}">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>@yield('title', 'Fundi Portal')</title>
+    @if (file_exists(public_path('build/manifest.json')))
+        @vite(['resources/css/app.css', 'resources/js/app.js'])
+    @endif
+</head>
+<body class="font-sans antialiased bg-gray-100">
+    <nav class="bg-white border-b border-gray-200">
+        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-4 flex justify-between">
+            <a href="/" class="text-lg font-semibold text-gray-700">Fundi Portal</a>
+            <div class="space-x-2">
+                @auth
+                    <a href="{{ route('dashboard') }}" class="text-gray-700 hover:text-gray-900 px-3">Dashboard</a>
+                    <form method="POST" action="{{ route('logout') }}" class="inline">
+                        @csrf
+                        <button type="submit" class="text-gray-700 hover:text-gray-900 px-3">Logout</button>
+                    </form>
+                @else
+                    <a href="{{ route('login') }}" class="text-gray-700 hover:text-gray-900 px-3">Login</a>
+                @endauth
+            </div>
+        </div>
+    </nav>
+    <main class="py-6">
+        <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
+            @yield('content')
+        </div>
+    </main>
+</body>
+</html>

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,7 +1,14 @@
 <?php
 
 use Illuminate\Support\Facades\Route;
+use App\Http\Controllers\Auth\LoginController;
 
 Route::get('/', function () {
     return view('welcome');
 });
+
+Route::get('/login', [LoginController::class, 'showLoginForm'])->name('login');
+Route::post('/login', [LoginController::class, 'login']);
+Route::post('/logout', [LoginController::class, 'logout'])->name('logout');
+
+Route::view('/dashboard', 'dashboard')->middleware('auth')->name('dashboard');

--- a/tests/Feature/DashboardTest.php
+++ b/tests/Feature/DashboardTest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Tests\Feature;
+
+use Tests\TestCase;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use App\Models\User;
+
+class DashboardTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /**
+     * Authenticated users can access the dashboard.
+     */
+    public function test_authenticated_user_can_view_dashboard(): void
+    {
+        $user = User::factory()->create();
+
+        $response = $this->actingAs($user)->get('/dashboard');
+
+        $response->assertStatus(200);
+        $response->assertSee('User Dashboard');
+    }
+}

--- a/tests/Feature/LoginTest.php
+++ b/tests/Feature/LoginTest.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Tests\Feature;
+
+use Tests\TestCase;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use App\Models\User;
+
+class LoginTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_login_screen_is_accessible(): void
+    {
+        $response = $this->get('/login');
+
+        $response->assertStatus(200);
+        $response->assertSee('Login');
+    }
+
+    public function test_user_can_login_with_correct_credentials(): void
+    {
+        $user = User::factory()->create([
+            'email' => 'user@example.com',
+            'password' => bcrypt('password123'),
+        ]);
+
+        $response = $this->post('/login', [
+            'email' => 'user@example.com',
+            'password' => 'password123',
+        ]);
+
+        $response->assertRedirect('/dashboard');
+        $this->assertAuthenticatedAs($user);
+    }
+}


### PR DESCRIPTION
## Summary
- implement simple login controller
- create login view
- update main layout with auth-aware nav and skip vite in tests
- protect dashboard route and add login routes
- update user factory and dashboard test
- add new login tests

## Testing
- `php artisan test`

------
https://chatgpt.com/codex/tasks/task_e_684c3c452de48331acb5cc06c3f4f6f7