### PR TITLE
Add user dashboard for service requests

### DIFF
--- a/app/Http/Controllers/Admin/InspectionRequestController.php
+++ b/app/Http/Controllers/Admin/InspectionRequestController.php
@@ -124,13 +124,31 @@ class InspectionRequestController extends Controller
         $properties = Property::all();
         $packages = InspectionPackage::active()->get();
         $businessPartners = BusinessPartner::active()->get();
-        $users = User::where('status', 'active')->get();
+
+        // Active individual clients
+        $individualUsers = User::active()->byRole('individual_client')->get();
+
+        // Map of partner ID => active users for form dropdowns
+        $businessPartnerUsers = [];
+        foreach ($businessPartners as $partner) {
+            $businessPartnerUsers[$partner->id] = $partner->users()
+                ->active()
+                ->get()
+                ->map(function (User $user) {
+                    return [
+                        'id' => $user->id,
+                        'full_name' => $user->full_name,
+                        'email' => $user->email,
+                    ];
+                });
+        }
 
         return view('admin.inspection-requests.create', compact(
-            'properties', 
-            'packages', 
-            'businessPartners', 
-            'users'
+            'properties',
+            'packages',
+            'businessPartners',
+            'individualUsers',
+            'businessPartnerUsers'
         ));
     }
 

--- a/app/Http/Controllers/DashboardController.php
+++ b/app/Http/Controllers/DashboardController.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+
+class DashboardController extends Controller
+{
+    /**
+     * Display the user dashboard.
+     */
+    public function index()
+    {
+        return view('dashboard');
+    }
+}

--- a/app/Http/Controllers/InspectionRequestController.php
+++ b/app/Http/Controllers/InspectionRequestController.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\InspectionPackage;
+use App\Models\InspectionRequest;
+use App\Models\Property;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Validator;
+
+class InspectionRequestController extends Controller
+{
+    /**
+     * Show the form for creating a new inspection request.
+     */
+    public function create()
+    {
+        $properties = Property::all();
+        $packages = InspectionPackage::active()->get();
+        $businessPartners = auth()->user()->businessPartners()->active()->get();
+
+        return view('inspection-requests.create', compact('properties', 'packages', 'businessPartners'));
+    }
+
+    /**
+     * Store a newly created inspection request.
+     */
+    public function store(Request $request)
+    {
+        $validator = Validator::make($request->all(), [
+            'property_id' => 'required|exists:properties,id',
+            'package_id' => 'required|exists:inspection_packages,id',
+            'purpose' => 'required|in:rental,sale,purchase,loan_collateral,insurance,maintenance,other',
+            'urgency' => 'required|in:normal,urgent,emergency',
+            'preferred_date' => 'nullable|date|after:today',
+            'preferred_time_slot' => 'required|in:morning,afternoon,evening,flexible',
+            'special_instructions' => 'nullable|string|max:1000',
+        ]);
+
+        if ($validator->fails()) {
+            return redirect()->back()->withErrors($validator)->withInput();
+        }
+
+        try {
+            DB::beginTransaction();
+
+            $package = InspectionPackage::findOrFail($request->package_id);
+
+            $inspectionRequest = InspectionRequest::create([
+                'request_number' => InspectionRequest::generateRequestNumber(),
+                'requester_type' => auth()->user()->isBusinessPartner() ? 'business_partner' : 'individual',
+                'requester_user_id' => auth()->id(),
+                'business_partner_id' => $request->business_partner_id,
+                'property_id' => $request->property_id,
+                'package_id' => $package->id,
+                'purpose' => $request->purpose,
+                'urgency' => $request->urgency,
+                'preferred_date' => $request->preferred_date,
+                'preferred_time_slot' => $request->preferred_time_slot,
+                'special_instructions' => $request->special_instructions,
+                'status' => 'pending',
+                'total_cost' => $package->price,
+                'payment_status' => 'pending',
+            ]);
+
+            DB::commit();
+
+            return redirect()->route('dashboard')->with('success', 'Inspection request submitted successfully.');
+        } catch (\Exception $e) {
+            DB::rollBack();
+            return redirect()->back()->with('error', 'Failed to submit request: ' . $e->getMessage())->withInput();
+        }
+    }
+}

--- a/app/Models/BusinessPartner.php
+++ b/app/Models/BusinessPartner.php
@@ -520,6 +520,24 @@ public function setPrimaryContact(User $user)
     }
 
     /**
+     * Calculate discounted price based on partner discounts.
+     */
+    public function calculateDiscountedPrice(float $price): float
+    {
+        $discount = $this->discount_percentage;
+
+        // Apply volume discount if it's greater than the set discount
+        $suggested = $this->getSuggestedDiscountPercentage();
+        if ($suggested > $discount) {
+            $discount = $suggested;
+        }
+
+        return $discount > 0
+            ? $price * (1 - ($discount / 100))
+            : $price;
+    }
+
+    /**
      * Create default business partners for Rwanda
      */
     public static function createDefaultPartners(): array

--- a/resources/views/dashboard.blade.php
+++ b/resources/views/dashboard.blade.php
@@ -1,0 +1,14 @@
+@extends('layouts.app')
+
+@section('title', 'Dashboard')
+
+@section('content')
+<div class="max-w-7xl mx-auto py-10">
+    <h1 class="text-2xl font-semibold mb-6">Welcome, {{ auth()->user()->full_name }}</h1>
+    <div class="space-y-4">
+        <a href="{{ route('inspection-requests.create') }}" class="inline-flex items-center rounded-md bg-indigo-600 px-4 py-2 text-white shadow hover:bg-indigo-500">
+            Request Inspection
+        </a>
+    </div>
+</div>
+@endsection

--- a/resources/views/inspection-requests/create.blade.php
+++ b/resources/views/inspection-requests/create.blade.php
@@ -1,0 +1,92 @@
+@extends('layouts.app')
+
+@section('title', 'Request Inspection')
+
+@section('content')
+<div class="max-w-4xl mx-auto py-8">
+    <h2 class="text-xl font-semibold mb-4">Request Inspection</h2>
+    <form method="POST" action="{{ route('inspection-requests.store') }}" class="space-y-6">
+        @csrf
+        <div>
+            <label for="property_id" class="block text-sm font-medium text-gray-700">Property</label>
+            <select name="property_id" id="property_id" required class="mt-1 block w-full border-gray-300 rounded-md">
+                <option value="">Choose property...</option>
+                @foreach($properties as $property)
+                    <option value="{{ $property->id }}" {{ old('property_id') == $property->id ? 'selected' : '' }}>
+                        {{ $property->property_code }} - {{ $property->address }}
+                    </option>
+                @endforeach
+            </select>
+            @error('property_id')<p class="text-sm text-red-600">{{ $message }}</p>@enderror
+        </div>
+
+        <div>
+            <label for="package_id" class="block text-sm font-medium text-gray-700">Inspection Package</label>
+            <select name="package_id" id="package_id" required class="mt-1 block w-full border-gray-300 rounded-md">
+                <option value="">Choose package...</option>
+                @foreach($packages as $package)
+                    <option value="{{ $package->id }}" {{ old('package_id') == $package->id ? 'selected' : '' }}>
+                        {{ $package->display_name }} - {{ number_format($package->price) }} RWF
+                    </option>
+                @endforeach
+            </select>
+            @error('package_id')<p class="text-sm text-red-600">{{ $message }}</p>@enderror
+        </div>
+
+        <div>
+            <label for="purpose" class="block text-sm font-medium text-gray-700">Purpose</label>
+            <select name="purpose" id="purpose" required class="mt-1 block w-full border-gray-300 rounded-md">
+                <option value="">Select purpose</option>
+                <option value="rental" {{ old('purpose') == 'rental' ? 'selected' : '' }}>Rental</option>
+                <option value="sale" {{ old('purpose') == 'sale' ? 'selected' : '' }}>Sale</option>
+                <option value="purchase" {{ old('purpose') == 'purchase' ? 'selected' : '' }}>Purchase</option>
+                <option value="loan_collateral" {{ old('purpose') == 'loan_collateral' ? 'selected' : '' }}>Loan Collateral</option>
+                <option value="insurance" {{ old('purpose') == 'insurance' ? 'selected' : '' }}>Insurance</option>
+                <option value="maintenance" {{ old('purpose') == 'maintenance' ? 'selected' : '' }}>Maintenance</option>
+                <option value="other" {{ old('purpose') == 'other' ? 'selected' : '' }}>Other</option>
+            </select>
+            @error('purpose')<p class="text-sm text-red-600">{{ $message }}</p>@enderror
+        </div>
+
+        <div>
+            <label for="urgency" class="block text-sm font-medium text-gray-700">Urgency</label>
+            <select name="urgency" id="urgency" required class="mt-1 block w-full border-gray-300 rounded-md">
+                <option value="normal" {{ old('urgency') == 'normal' ? 'selected' : '' }}>Normal</option>
+                <option value="urgent" {{ old('urgency') == 'urgent' ? 'selected' : '' }}>Urgent</option>
+                <option value="emergency" {{ old('urgency') == 'emergency' ? 'selected' : '' }}>Emergency</option>
+            </select>
+            @error('urgency')<p class="text-sm text-red-600">{{ $message }}</p>@enderror
+        </div>
+
+        <div class="grid grid-cols-2 gap-4">
+            <div>
+                <label for="preferred_date" class="block text-sm font-medium text-gray-700">Preferred Date</label>
+                <input type="date" name="preferred_date" id="preferred_date" value="{{ old('preferred_date') }}" class="mt-1 block w-full border-gray-300 rounded-md" />
+                @error('preferred_date')<p class="text-sm text-red-600">{{ $message }}</p>@enderror
+            </div>
+            <div>
+                <label for="preferred_time_slot" class="block text-sm font-medium text-gray-700">Time Slot</label>
+                <select name="preferred_time_slot" id="preferred_time_slot" required class="mt-1 block w-full border-gray-300 rounded-md">
+                    <option value="morning" {{ old('preferred_time_slot') == 'morning' ? 'selected' : '' }}>Morning</option>
+                    <option value="afternoon" {{ old('preferred_time_slot') == 'afternoon' ? 'selected' : '' }}>Afternoon</option>
+                    <option value="evening" {{ old('preferred_time_slot') == 'evening' ? 'selected' : '' }}>Evening</option>
+                    <option value="flexible" {{ old('preferred_time_slot', 'flexible') == 'flexible' ? 'selected' : '' }}>Flexible</option>
+                </select>
+                @error('preferred_time_slot')<p class="text-sm text-red-600">{{ $message }}</p>@enderror
+            </div>
+        </div>
+
+        <div>
+            <label for="special_instructions" class="block text-sm font-medium text-gray-700">Special Instructions</label>
+            <textarea name="special_instructions" id="special_instructions" rows="4" class="mt-1 block w-full border-gray-300 rounded-md">{{ old('special_instructions') }}</textarea>
+            @error('special_instructions')<p class="text-sm text-red-600">{{ $message }}</p>@enderror
+        </div>
+
+        <div>
+            <button type="submit" class="inline-flex items-center rounded-md bg-indigo-600 px-4 py-2 text-white shadow hover:bg-indigo-500">
+                Submit Request
+            </button>
+        </div>
+    </form>
+</div>
+@endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -2,6 +2,8 @@
 
 use Illuminate\Support\Facades\Route;
 use App\Http\Controllers\Auth\LoginController;
+use App\Http\Controllers\DashboardController;
+use App\Http\Controllers\InspectionRequestController as UserInspectionRequestController;
 
 Route::get('/', function () {
     return view('welcome');
@@ -11,8 +13,12 @@ Route::get('/login', [LoginController::class, 'showLoginForm'])->name('login');
 Route::post('/login', [LoginController::class, 'login']);
 Route::post('/logout', [LoginController::class, 'logout'])->name('logout');
 
-// Basic dashboard (your existing one)
-Route::view('/dashboard', 'dashboard')->middleware('auth')->name('dashboard');
+// Authenticated user routes
+Route::middleware('auth')->group(function () {
+    Route::get('/dashboard', [DashboardController::class, 'index'])->name('dashboard');
+    Route::get('/inspection-requests/create', [UserInspectionRequestController::class, 'create'])->name('inspection-requests.create');
+    Route::post('/inspection-requests', [UserInspectionRequestController::class, 'store'])->name('inspection-requests.store');
+});
 
 // Admin Routes (Protected by admin middleware)
 Route::middleware(['auth', 'admin'])->prefix('admin')->name('admin.')->group(function () {


### PR DESCRIPTION
## Summary
- add user `DashboardController`
- support user inspection requests via new controller and form view
- update routes to expose dashboard and request form

## Testing
- ❌ `composer install --no-interaction --no-progress` (command not found)


------
https://chatgpt.com/codex/tasks/task_e_684eda336a5c8331ad64434b3fcb49ca