### PR TITLE
Update blade conditional to avoid missing variable crash

### DIFF
--- a/resources/views/admin/inspection-requests/create.blade.php
+++ b/resources/views/admin/inspection-requests/create.blade.php
@@ -37,7 +37,7 @@
     <form method="POST" action="{{ route('inspection-requests.store') }}" class="space-y-6">
         @csrf
 
-        @if(!$isIndividual)
+        @if(isset($isIndividual) && !$isIndividual)
             <!-- Enhanced Property Selection -->
             <div>
                 <div class="flex items-center justify-between mb-2">
@@ -160,7 +160,7 @@
                 <label for="district" class="block text-sm font-medium text-gray-700">District</label>
                 <select name="district" id="district" required class="mt-1 block w-full border-gray-300 rounded-md">
                     <option value="">Choose district...</option>
-                    @foreach($districts as $district)
+                    @foreach(($districts ?? []) as $district)
                         <option value="{{ $district }}" {{ old('district') == $district ? 'selected' : '' }}>{{ $district }}</option>
                     @endforeach
                 </select>
@@ -170,7 +170,7 @@
                 <label for="property_type" class="block text-sm font-medium text-gray-700">Property Type</label>
                 <select name="property_type" id="property_type" required class="mt-1 block w-full border-gray-300 rounded-md">
                     <option value="">Choose type...</option>
-                    @foreach($propertyTypes as $type => $label)
+                    @foreach(($propertyTypes ?? []) as $type => $label)
                         <option value="{{ $type }}" {{ old('property_type') == $type ? 'selected' : '' }}>{{ $label }}</option>
                     @endforeach
                 </select>


### PR DESCRIPTION
## Summary
- handle cases where controller doesn't pass `$isIndividual`
- fallback to empty lists when `$districts` or `$propertyTypes` aren't defined

## Testing
- `phpunit --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f5568caa4833189ac94e83f246782